### PR TITLE
Make empty array.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "jsonc-parser": "^3.3.1"
     },
     "name": "jsonui-scripting",
-    "version": "2.3.2",
+    "version": "2.3.3",
     "description": "Make your Minecraft JsonUI with ScriptingAPI",
     "main": "./dist/cjs/index.js",
     "module": "./dist/esm/index.js",


### PR DESCRIPTION
Vi:
- Vẫn có người (chắc là mỗi mình tôi) clear hết các đối tượng của những array như controls, bindings, variables của các element trong Vanilla bằng cách ghi đè bằng mảng rỗng.

- Nên hãy cho phép .addChild, .addBindings, .addVariables của Modify.override được phép không truyền tham số để tạo một mảng mà không thêm đối tượng vào trong.
  
- Điều này không được áp dụng với UI ("VÌ CHẴN AI LÀM THẾ:v")